### PR TITLE
Create mapped users at container runtime (SOFTWARE-4300)

### DIFF
--- a/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -3,7 +3,7 @@
 . ce-common-startup
 
 users=$(get_mapped_users)
-for user in "$users"; do
+for user in $users; do
     echo "Creating local user ($user)..."
     adduser --base-dir /home/ "$user"
 done

--- a/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+. ce-common-startup
+
+users=$(get_mapped_users)
+for user in "$users"; do
+    echo "Creating local user ($user)..."
+    adduser --base-dir /home/ "$user"
+done
+
 #kubernetes configmaps arent writeable
 stat /tmp/99-local.ini
 if [[ $? -eq 0 ]]; then

--- a/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. ce-common-startup
+. /etc/osg/image-config.d/ce-common-startup
 
 users=$(get_mapped_users)
 for user in $users; do

--- a/etc/osg/image-config.d/ce-common-startup
+++ b/etc/osg/image-config.d/ce-common-startup
@@ -1,0 +1,6 @@
+# Return list of local users mapped from grid credentials
+function get_mapped_users () {
+    cat /etc/grid-security/grid-mapfile /etc/grid-security/voms-mapfile | \
+        awk '/^"[^"]+" +[a-zA-Z0-9\-\._]+$/ {print $NF}' | \
+        sort -u
+}

--- a/etc/osg/image-config.d/ce-common-startup
+++ b/etc/osg/image-config.d/ce-common-startup
@@ -1,6 +1,6 @@
 # Return list of local users mapped from grid credentials
 function get_mapped_users () {
-    cat /etc/grid-security/grid-mapfile /etc/grid-security/voms-mapfile | \
-        awk '/^"[^"]+" +[a-zA-Z0-9\-\._]+$/ {print $NF}' | \
+    cat /etc/grid-security/grid-mapfile /etc/grid-security/voms-mapfile |
+        awk '/^"[^"]+" +[a-zA-Z0-9\-\._]+$/ {print $NF}' |
         sort -u
 }


### PR DESCRIPTION
I decided to just throw the common lib into the same dir as the scripts that'll use it. No `.sh` suffix since the software base sources based on it. 