### PR TITLE
Prevent CEs from coming up in a misconfigured state

### DIFF
--- a/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -2,7 +2,7 @@
 
 . /etc/osg/image-config.d/ce-common-startup
 
-set -x
+set -e
 
 users=$(get_mapped_users)
 for user in $users; do

--- a/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -2,6 +2,8 @@
 
 . /etc/osg/image-config.d/ce-common-startup
 
+set -x
+
 users=$(get_mapped_users)
 for user in $users; do
     echo "Creating local user ($user)..."


### PR DESCRIPTION
It'd be better if CEs bailed as early as possible in the startup process.

Note that this image is intended to be the base for:

- https://github.com/opensciencegrid/docker-hosted-ce/
- https://github.com/opensciencegrid/docker-htcondor-ce/ (currently used by the Open Science CE) 
- https://github.com/opensciencegrid/docker-osg-ce-condor/ (currently used for ITB CEs on Tiger)