### PR TITLE
Enable xtrace in CE startup scripts for easier debugging

### DIFF
--- a/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -2,7 +2,7 @@
 
 . /etc/osg/image-config.d/ce-common-startup
 
-set -e
+set -xe
 
 users=$(get_mapped_users)
 for user in $users; do

--- a/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -64,3 +64,5 @@ openssl x509 -in $hostcert_path -text
 echo "><><><><><><><><><><><><><><><><><><><"
 
 chown -R condor:condor /var/log/condor-ce /var/lib/condor-ce/spool
+
+set +xe


### PR DESCRIPTION
All images inheriting from 'opensciencegrid/compute-entrypoint' should
have additional startup scripts after 20-osg-ce-setup.sh