### PR TITLE
Remove duplicate adduser

### DIFF
--- a/hosted-ce/30-remote-site-setup.sh
+++ b/hosted-ce/30-remote-site-setup.sh
@@ -36,10 +36,9 @@ function fetch_remote_os_info {
 }
 
 setup_ssh_config () {
-  echo "Adding user ${ruser}"
+  echo "Setting up SSH for user ${ruser}"
   ssh_dir="/home/${ruser}/.ssh"
   # setup user and SSH dir
-  adduser --base-dir /home/ "${ruser}"
   mkdir -p $ssh_dir
   chown "${ruser}": $ssh_dir
   chmod 700 $ssh_dir


### PR DESCRIPTION
`release` images are failing with:

```
++ adduser --base-dir /home/ osg01
adduser: user 'osg01' already exists
```