### PR TITLE
Add the workflow run ID to the cache key

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache
-        key: base-${{ matrix.repo }}-buildx-${{ github.sha }}
+        key: base-${{ matrix.repo }}-buildx-${{ github.sha }}-${{ github.run_id }}
         # allow cache hits from previous runs of the current branch,
         # parent branch, then upstream branches, in that order
         restore-keys: |
@@ -70,7 +70,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache
-        key: base-${{ matrix.repo }}-buildx-${{ github.sha }}
+        key: base-${{ matrix.repo }}-buildx-${{ github.sha }}-${{ github.run_id }}
 
     - name: Generate tag list
       id: generate-tag-list


### PR DESCRIPTION
N.B. run IDs don't change on re-runs of a given workflow run

Otherwise dispatch runs will use caches from the previous week if
there haven't been any changes to the underlying repo. Luckily Docker
seems to treat these cached layers as stale: the only real effect
is that the child image builds rebuild the base and child stages so
they take longer to build and they technically don't share the same base.