### PR TITLE
Ensure that new PVCs have the appropriate subdirs (SOFTWARE-4423)

### DIFF
--- a/base/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/base/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -64,7 +64,7 @@ openssl x509 -in $hostcert_path -text
 echo "><><><><><><><><><><><><><><><><><><><"
 
 # Ensure that PVC dirs and subdirs exist and have the proper
-# permissions (SOFTWARE-4423)
+# ownership (SOFTWARE-4423)
 mkdir -p \
       /var/log/condor-ce/ \
       /var/lib/condor-ce/execute \

--- a/base/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/base/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -63,6 +63,14 @@ echo ">>>>> YOUR CERTIFICATE INFORMATION IS:"
 openssl x509 -in $hostcert_path -text
 echo "><><><><><><><><><><><><><><><><><><><"
 
-chown -R condor:condor /var/log/condor-ce /var/lib/condor-ce/spool
+# Ensure that PVC dirs and subdirs exist and have the proper
+# permissions (SOFTWARE-4423)
+mkdir -p \
+      /var/log/condor-ce/ \
+      /var/lib/condor-ce/execute \
+      /var/lib/condor-ce/spool/ceview/{metrics,vos}
+chown -R condor:condor \
+      /var/log/condor-ce \
+      /var/lib/condor-ce/
 
 set +xe


### PR DESCRIPTION
Should be harmless if the dirs already exist (i.e., no PVCs mounted into `/var/log/condor-ce` or `/var/lib/condor-ce/`)