### PR TITLE
Allow users to specify the remote batch_gahp script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,8 @@ RUN [[ $BASE_YUM_REPO != 'release' ]] || patch -d / -p0 < /tmp/HTCONDOR-242.remo
 # Required for HTCondor 9.0.0 on the CE and Bosco 1.3 usage
 # Can be dropped when HTCONDOR-451 has been fixed and released in the OSG
 COPY hosted-ce/overrides/HTCONDOR-451.allow-batch_gahp.patch /tmp
-RUN [[ $BASE_YUM_REPO == 'release' ]] || patch -d / -p0 < /tmp/HTCONDOR-451.allow-batch_gahp.patch
+COPY hosted-ce/overrides/HTCONDOR-451.allow-batch_gahp-2.patch /tmp
+RUN [[ $BASE_YUM_REPO == 'release' ]] || { patch -d / -p0 < /tmp/HTCONDOR-451.allow-batch_gahp.patch && patch -d / -p0 < /tmp/HTCONDOR-451.allow-batch_gahp-2.patch; }
 
 # Set up Bosco override dir from Git repo (SOFTWARE-3903)
 # Expects a Git repo with the following directory structure:

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,12 @@ RUN patch -d / -p0 < /tmp/skip_key_copy.patch
 COPY hosted-ce/overrides/HTCONDOR-242.remote-os-detection.patch /tmp
 RUN [[ $BASE_YUM_REPO != 'release' ]] || patch -d / -p0 < /tmp/HTCONDOR-242.remote-os-detection.patch
 
+# Allow the Gridmanager to specify 'batch_gahp' for its remote command
+# Required for HTCondor 9.0.0 on the CE and Bosco 1.3 usage
+# Can be dropped when HTCONDOR-451 has been fixed and released in the OSG
+COPY hosted-ce/overrides/HTCONDOR-451.allow-batch_gahp.patch /tmp
+RUN [[ $BASE_YUM_REPO == 'release' ]] || patch -d / -p0 < /tmp/HTCONDOR-451.allow-batch_gahp.patch
+
 # Set up Bosco override dir from Git repo (SOFTWARE-3903)
 # Expects a Git repo with the following directory structure:
 #     RESOURCE_NAME_1/

--- a/hosted-ce/overrides/HTCONDOR-451.allow-batch_gahp-2.patch
+++ b/hosted-ce/overrides/HTCONDOR-451.allow-batch_gahp-2.patch
@@ -1,0 +1,39 @@
+HTCONDOR-451.allow-batch_gahp-2
+
+Jaime's fix on top of HTCONDOR-451.allow-batch_gahp.patch
+
+---
+ src/condor_gridmanager/remote_gahp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/condor_gridmanager/remote_gahp b/src/condor_gridmanager/remote_gahp
+index db30b8262b..20da8d86dc 100755
+--- /usr/sbin/remote_gahp
++++ /usr/sbin/remote_gahp
+@@ -78,21 +78,21 @@ while [ $# != 0 ] ; do
+             echo -e "$USAGE"
+             exit 1;;
+         -- ) shift
+-            if [ "$REMOTE_CMD" = "" ] ; then
++            if [ "$REMOTE_CMD" = "" -o "$1" = "condor_ft-gahp" ] ; then
+                 REMOTE_CMD="$1"
+                 shift
+             fi
+             break;;
+         -* ) break;;
+         * )
+             if [ "$REMOTE_HOSTNAME" = "" ] ; then
+                 if  [[ $1 =~ ^(([A-Za-z_][A-Za-z0-9_-]*)@)?([A-Za-z0-9\.-]+)(:([0-9]*))?$ ]]; then
+                     REMOTE_USER="${BASH_REMATCH[2]:-$REMOTE_USER}"
+                     REMOTE_HOSTNAME="${BASH_REMATCH[3]:-$REMOTE_HOSTNAME}"
+                     REMOTE_PORT="${BASH_REMATCH[5]:-$REMOTE_PORT}"
+                 fi
+                 shift
+-            elif [ "$REMOTE_CMD" = "" ] ; then
++            elif [ "$REMOTE_CMD" = "" -o "$1" = "condor_ft-gahp" ] ; then
+                 REMOTE_CMD="$1"
+                 shift
+             else
+-- 
+2.30.2
+

--- a/hosted-ce/overrides/HTCONDOR-451.allow-batch_gahp.patch
+++ b/hosted-ce/overrides/HTCONDOR-451.allow-batch_gahp.patch
@@ -2,6 +2,24 @@ diff --git a/src/condor_gridmanager/remote_gahp b/src/condor_gridmanager/remote_
 index 8a253bdab5..5b49a8d507 100755
 --- /usr/sbin/remote_gahp
 +++ /usr/sbin/remote_gahp
+@@ -78,7 +78,7 @@
+             echo -e "$USAGE"
+             exit 1;;
+         -- ) shift
+-            if [ "$REMOTE_CMD" = "" ] ; then
++            if [ "$REMOTE_CMD" = "" -o "$1" = "condor_ft-gahp" ] ; then
+                 REMOTE_CMD="$1"
+                 shift
+             fi
+@@ -92,7 +92,7 @@
+                     REMOTE_PORT="${BASH_REMATCH[5]:-$REMOTE_PORT}"
+                 fi
+                 shift
+-            elif [ "$REMOTE_CMD" = "" ] ; then
++            elif [ "$REMOTE_CMD" = "" -o "$1" = "condor_ft-gahp" ] ; then
+                 REMOTE_CMD="$1"
+                 shift
+             else
 @@ -150,8 +150,8 @@ SSH_ARGS=(-p $REMOTE_PORT)
  [[ $SSH_BATCHMODE == "yes" ]] && SSH_ARGS+=(-o "BatchMode yes")
  

--- a/hosted-ce/overrides/HTCONDOR-451.allow-batch_gahp.patch
+++ b/hosted-ce/overrides/HTCONDOR-451.allow-batch_gahp.patch
@@ -1,0 +1,15 @@
+diff --git a/src/condor_gridmanager/remote_gahp b/src/condor_gridmanager/remote_gahp
+index 8a253bdab5..5b49a8d507 100755
+--- /usr/sbin/remote_gahp
++++ /usr/sbin/remote_gahp
+@@ -150,8 +150,8 @@ SSH_ARGS=(-p $REMOTE_PORT)
+ [[ $SSH_BATCHMODE == "yes" ]] && SSH_ARGS+=(-o "BatchMode yes")
+ 
+ #echo "** Follows output of: ssh ${SSH_ARGS[@]} $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -c \"'GLITE_LOCATION=$REMOTE_GLITE $REMOTE_GLITE/bin/blahpd $*'\""
+-if [ "${REMOTE_CMD}" = "blahpd" ] ; then
+-    ssh "${SSH_ARGS[@]}" $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -l -c "'GLITE_LOCATION=$REMOTE_GLITE $REMOTE_GLITE/bin/blahpd $*'"
++if [[ $REMOTE_CMD == "blahpd" || $REMOTE_CMD == "batch_gahp" ]] ; then
++    ssh "${SSH_ARGS[@]}" $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -l -c "'GLITE_LOCATION=$REMOTE_GLITE $REMOTE_GLITE/bin/$REMOTE_CMD $*'"
+     SSH_STATUS=$?
+ elif [ "${REMOTE_CMD}" = "condor_ft-gahp" ] ; then
+     # We need to set up a tunnel from the remote machine for the file


### PR DESCRIPTION
This is required for Bosco 1.3 tarball usage with HTCondor 9.0.0 on
the CE

From here, my plan is to add some bits to the helm chart that will specify `--rgahp-glite batch_gahp` if the user specifies a Bosco 1.3 tarball