### PR TITLE
batch_gahp patches only apply to 9.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ RUN [[ $BASE_YUM_REPO != 'release' ]] || patch -d / -p0 < /tmp/HTCONDOR-242.remo
 # Required for HTCondor 9.0.0 on the CE and Bosco 1.3 usage
 # Can be dropped when HTCONDOR-451 has been fixed and released in the OSG
 COPY hosted-ce/overrides/HTCONDOR-451.allow-batch_gahp.patch /tmp
-RUN [[ $BASE_YUM_REPO == 'release' ]] || patch -d / -p0 < /tmp/HTCONDOR-451.allow-batch_gahp.patch
+RUN [[ $BASE_YUM_REPO != 'testing' ]] || patch -d / -p0 < /tmp/HTCONDOR-451.allow-batch_gahp.patch
 
 # Set up Bosco override dir from Git repo (SOFTWARE-3903)
 # Expects a Git repo with the following directory structure:


### PR DESCRIPTION
Which is currently only relevant for 'osg-testing'. I'm waiting on the 9.0.1 RC1 to hit upcoming-development before requesting a review.