### PR TITLE
Apply Bosco 1.3 compat patch to 9.0.0 in testing/release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ RUN [[ $BASE_YUM_REPO != 'release' ]] || patch -d / -p0 < /tmp/HTCONDOR-242.remo
 # Required for HTCondor 9.0.0 on the CE and Bosco 1.3 usage
 # Can be dropped when HTCONDOR-451 has been fixed and released in the OSG
 COPY hosted-ce/overrides/HTCONDOR-451.allow-batch_gahp.patch /tmp
-RUN [[ $BASE_YUM_REPO != 'testing' ]] || patch -d / -p0 < /tmp/HTCONDOR-451.allow-batch_gahp.patch
+RUN [[ $BASE_YUM_REPO == 'development' ]] || patch -d / -p0 < /tmp/HTCONDOR-451.allow-batch_gahp.patch
 
 # Set up Bosco override dir from Git repo (SOFTWARE-3903)
 # Expects a Git repo with the following directory structure:


### PR DESCRIPTION
We need this Bosco patch applied to 9.0.0 when we build the `release` tag once 9.0.0 has been released and is available from `repo`. 