### PR TITLE
Patch doesn't apply cleanly to htcondor-ce-5.1.0-1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY base/overrides/condor_ce_jobmetrics /usr/share/condor-ce/condor_ce_jobmetri
 
 # Workaround BatchRuntime expresion bug (HTCONDOR-506)
 COPY base/overrides/HTCONDOR-506.evalset-batchruntime.patch /tmp
-RUN patch -d / -p0 < /tmp/HTCONDOR-506.evalset-batchruntime.patch
+RUN [[ $BASE_YUM_REPO == 'development' ]] || patch -d / -p0 < /tmp/HTCONDOR-506.evalset-batchruntime.patch
 
 #################
 # osg-ce-condor #


### PR DESCRIPTION
That RPM contains a patch that fixes a typo that's covered in our patch.

Currently, the GHA is setup so that failure in one child image doesn't prevent build/push for the other child images but I don't think that's easy to do if the failure is in the parent image. Another reason why I regret this whole parent/child setup in the CE/XCache images.