### PR TITLE
Symlink to host cert/key in /etc/grid-security-orig.d

### DIFF
--- a/base/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/base/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -49,8 +49,8 @@ fi
 hostcert_path=/etc/grid-security/hostcert.pem
 hostkey_path=/etc/grid-security/hostkey.pem
 hostcsr_path=/etc/grid-security/host.req
-orig_hostcert_path=/etc/grid-security-orig.d/tls.crt
-orig_hostkey_path=/etc/grid-security-orig.d/tls.key
+orig_hostcert_path=/etc/grid-security-orig.d/hostcert.pem
+orig_hostkey_path=/etc/grid-security-orig.d/hostkey.pem
 
 certbot_opts="--noninteractive --agree-tos --standalone --email $CE_CONTACT -d $CE_HOSTNAME"
 

--- a/base/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/base/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -39,6 +39,13 @@ if [ "${DEVELOPER,,}" == 'true' ]; then
     osg-ca-generator --host --vo osgtest
 fi
 
+
+# For host certs, we want to support the following use cases:
+# 1. Support mounting of a cert/key pair to /etc/grid-security-orig.d/.
+#    Useful for Kubernetes setups so that secret updates can be
+#    propagated to the container without a restart
+# 2. Support direct mounts of /etc/grid-security/host{cert,key}.pem
+# 3. Requesting LE certs if no host cert/key pair is mounted using the above
 hostcert_path=/etc/grid-security/hostcert.pem
 hostkey_path=/etc/grid-security/hostkey.pem
 hostcsr_path=/etc/grid-security/host.req


### PR DESCRIPTION
(SOFTWARE-4623)

We want to mount cert-manager secrets without subPath (i.e., into a
dir) so that updates to the secret are propagated into the container
without requiring a container redeploy.

SLATE is expecting these changes here: https://github.com/slateci/slate-catalog/pull/496