### PR TITLE
Only apply the HTCONDOR-451 patch to 'release'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN patch -d / -p0 < /tmp/HTCONDOR-503.add-sl-support.patch
 # Required for HTCondor 9.0.0 on the CE and Bosco 1.3 usage
 # Can be dropped when HTCONDOR-451 has been fixed and released in the OSG
 COPY hosted-ce/overrides/HTCONDOR-451.allow-batch_gahp.patch /tmp
-RUN [[ $BASE_YUM_REPO == 'development' ]] || patch -d / -p0 < /tmp/HTCONDOR-451.allow-batch_gahp.patch
+RUN [[ $BASE_YUM_REPO != 'release' ]] || patch -d / -p0 < /tmp/HTCONDOR-451.allow-batch_gahp.patch
 
 # Set up Bosco override dir from Git repo (SOFTWARE-3903)
 # Expects a Git repo with the following directory structure:


### PR DESCRIPTION
Yet another hack (HTCondor 9.0.1 made it into testing). I'll make a ticket for fixing this as we discussed on Slack