### PR TITLE
Fixup repo name (SOFTWARE-4718)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -101,7 +101,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        
+
     - name: Log in to OSG Harbor
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -81,7 +81,7 @@ jobs:
         IMAGE: ${{ matrix.image }}
         TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
       run: |
-        docker_repo=${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}
+        docker_repo=opensciencegrid/$IMAGE
         tag_list=()
         for registry in hub.opensciencegrid.org docker.io; do
           for image_tag in "$REPO" "$REPO-$TIMESTAMP"; do

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
   repository_dispatch:
     types:
       - dispatch-build
@@ -112,7 +113,7 @@ jobs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v2.2.2
       with:
-        push: True
+        push: ${{ github.event_name != pull_request }}
         context: .
         build-args: BASE_YUM_REPO=${{ matrix.repo }}
         tags: "${{ steps.generate-tag-list.outputs.taglist }}"


### PR DESCRIPTION
@mtru32 I missed https://github.com/opensciencegrid/docker-compute-entrypoint/commit/555e693ead1c14f475a674dff17afdcf06f6e278 in my review so this resulted in build failures. Could you make sure that the tag list before/after look the same except for the fact that after should have the same tags prefixed by `docker.io/` and `hub.opensciencegrid.org/`?