### PR TITLE
Add condor_ce_q_project script that prints more useful fields for allocation-based submissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ RUN if ! fgrep '(rhel|centos|scientific)' /usr/bin/bosco_cluster; then  \
     fi
 
 COPY hosted-ce/ssh-to-login-node /usr/local/bin
+COPY hosted-ce/condor_ce_q_project /usr/local/bin
 
 # Set up Bosco override dir from Git repo (SOFTWARE-3903)
 # Expects a Git repo with the following directory structure:

--- a/hosted-ce/condor_ce_q_project
+++ b/hosted-ce/condor_ce_q_project
@@ -1,5 +1,5 @@
 #!/bin/sh
-condor_ce_q --print-format - "$@" <<'__END__'
+condor_ce_q -print-format - "$@" <<'__END__'
 SELECT
     (RoutedJob ?: "-")                          AS "R"   WIDTH 1
     ID                                          AS "JOB ID"   PRINTAS JOB_ID WIDTH 8

--- a/hosted-ce/condor_ce_q_project
+++ b/hosted-ce/condor_ce_q_project
@@ -1,8 +1,11 @@
 #!/bin/sh
 condor_ce_q -print-format - "$@" <<'__END__'
 SELECT
-    (RoutedJob ?: "-")                          AS "R"   WIDTH 1
-    ID                                          AS "JOB ID"   PRINTAS JOB_ID WIDTH 8
+    (RoutedFromJobId ?: "")                     AS "    FROM" WIDTH 8
+    (!isUndefined(RoutedFromJobId) ? " ->" : "") AS " " WIDTH 3
+    ID                                          AS "  JOB ID"   PRINTAS JOB_ID WIDTH 8
+    (!isUndefined(RoutedToJobId) ? "-> " : "")  AS " " WIDTH 3
+    (RoutedToJobId ?: "")                       AS "TO" WIDTH -8
     Owner                                       AS "OWNER"   PRINTAS OWNER WIDTH -8
     QDate                                       AS " SUBMITTED"   PRINTAS QDATE WIDTH -12
     JobStatus                                   AS "STATUS"   PRINTAS JOB_STATUS

--- a/hosted-ce/condor_ce_q_project
+++ b/hosted-ce/condor_ce_q_project
@@ -1,0 +1,15 @@
+#!/bin/sh
+condor_ce_q --print-format - "$@" <<'__END__'
+SELECT
+    (RoutedJob ?: "-")                          AS "R"   WIDTH 1
+    ID                                          AS "JOB ID"   PRINTAS JOB_ID WIDTH 8
+    Owner                                       AS "OWNER"   PRINTAS OWNER WIDTH -8
+    QDate                                       AS " SUBMITTED"   PRINTAS QDATE WIDTH -12
+    JobStatus                                   AS "STATUS"   PRINTAS JOB_STATUS
+    EnteredCurrentStatus                        AS " SINCE"   PRINTAS QDATE WIDTH -12
+    (OSG_PROJECT_NAME ?: (ProjectName ?: "-"))  AS "[OSG] PROJECT NAME"
+    (BatchProject ?: "-")                       AS "BATCH PROJECT"
+GROUP BY
+    Owner
+__END__
+


### PR DESCRIPTION
Example output:
```
R JOB ID   OWNER     SUBMITTED   STATUS  SINCE       [OSG] PROJECT NAME              BATCH PROJECT
-    259.0 osg       8/17 04:12  R       8/17 04:14  TG-DDM160003                    -
t    260.0 osg       8/17 04:12  R       8/17 04:14  TG-DDM160003                    TG-DDM160003
-    261.0 osg       8/17 04:15  R       8/17 04:16  TG-DDM160003                    -
t    262.0 osg       8/17 04:15  R       8/17 04:16  TG-DDM160003                    TG-DDM160003
-    269.0 osg       8/17 19:12  R       8/17 19:14  GravSearches,UTAustin_Zimmerman -
t    270.0 osg       8/17 19:13  R       8/17 19:14  UTAustin_Zimmerman              GravSearches
-    271.0 osg       8/17 19:15  R       8/17 19:17  GravSearches,UTAustin_Zimmerman -
t    272.0 osg       8/17 19:15  R       8/17 19:17  UTAustin_Zimmerman              GravSearches
```
(the R column is whether the job is routed)