### PR TITLE
Add release series specific container tags (SOFTWARE-4944)

### DIFF
--- a/.github/workflows/release-series-images.yml
+++ b/.github/workflows/release-series-images.yml
@@ -1,0 +1,125 @@
+name: Build release series tagged container images
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  repository_dispatch:
+    types:
+      - dispatch-build
+  workflow_dispatch:
+
+jobs:
+  make-date-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      dtag: ${{ steps.mkdatetag.outputs.dtag }}
+    steps:
+    - name: make date tag
+      id: mkdatetag
+      run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
+
+  base-image-build:
+    name: compute-entrypoint:${{ matrix.osg_series }}-${{ matrix.repo }} image build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: False
+      matrix:
+        repo: ['development', 'testing', 'release']
+        osg_series: ['3.5', '3.6']
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Cache base image
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: base-${{ matrix.osg_series }}-${{ matrix.repo }}-buildx-${{ github.sha }}-${{ github.run_id }}
+        # allow cache hits from previous runs of the current branch,
+        # parent branch, then upstream branches, in that order
+        restore-keys: |
+          base-${{ matrix.repo }}-buildx-
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Build Docker image
+      uses: docker/build-push-action@v2.2.2
+      with:
+        build-args: |
+          BASE_YUM_REPO=${{ matrix.repo }}
+          BASE_OSG_SERIES=${{ matrix.osg_series }}
+        context: .
+        pull: True
+        target: base
+        cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
+
+  child-image-builds:
+    name: ${{ matrix.image }}:${{ matrix.osg_series}}-${{ matrix.repo }} image build
+    runs-on: ubuntu-latest
+    needs: [make-date-tag, base-image-build]
+    strategy:
+      fail-fast: False
+      matrix:
+        repo: ['development', 'testing', 'release']
+        image: ['hosted-ce', 'osg-ce-condor']
+        osg_series: ['3.5', '3.6']
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Load cached base image
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: base-${{ matrix.osg_series }}-${{ matrix.repo }}-buildx-${{ github.sha }}-${{ github.run_id }}
+
+    - name: Generate tag list
+      id: generate-tag-list
+      env:
+        REPO: ${{ matrix.repo }}
+        IMAGE: ${{ matrix.image }}
+        OSG_SERIES: ${{ matrix.osg_series }}
+        TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
+      run: |
+        docker_repo=opensciencegrid/$IMAGE
+        tag_list=()
+        for registry in hub.opensciencegrid.org docker.io; do
+          for image_tag in "$OSG_SERIES-$REPO" "$OSG_SERIES-$REPO-$TIMESTAMP"; do
+            tag_list+=("$registry/$docker_repo":"$image_tag")
+          done
+        done
+        # This causes the tag_list array to be comma-separated below,
+        # which is required for build-push-action
+        IFS=,
+        echo "::set-output name=taglist::${tag_list[*]}"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v1
+      if: github.event_name != 'pull_request' && startsWith(github.repository, 'opensciencegrid/')
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Log in to OSG Harbor
+      uses: docker/login-action@v1
+      if: github.event_name != 'pull_request' && startsWith(github.repository, 'opensciencegrid/')
+      with:
+        registry: hub.opensciencegrid.org
+        username: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
+        password: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2.2.2
+      with:
+        push: ${{ github.event_name != 'pull_request' && startsWith(github.repository, 'opensciencegrid/') }}
+        context: .
+        build-args: BASE_YUM_REPO=${{ matrix.repo }}
+        tags: "${{ steps.generate-tag-list.outputs.taglist }}"
+        target: ${{ matrix.image }}
+        cache-from: type=local,src=/tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,14 @@
 
 # Specify the opensciencegrid/software-base image tag
 ARG BASE_YUM_REPO=release
+ARG BASE_OSG_SERIES=3.5
 
-FROM opensciencegrid/software-base:3.5-el7-$BASE_YUM_REPO AS base
+FROM opensciencegrid/software-base:$BASE_OSG_SERIES-el7-$BASE_YUM_REPO AS base
 LABEL maintainer "OSG Software <help@opensciencegrid.org>"
 
-# previous arg has gone out of scope
+# previous args have gone out of scope
 ARG BASE_YUM_REPO=release
+ARG BASE_OSG_SERIES=3.5
 
 # Ensure that the 'condor' UID/GID matches across containers
 RUN groupadd -g 64 -r condor && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,12 @@ RUN groupadd -g 64 -r condor && \
     useradd -r -g condor -d /var/lib/condor -s /sbin/nologin \
       -u 64 -c "Owner of HTCondor Daemons" condor
 
-RUN yum install -y osg-ce-bosco \
+RUN if [[ $BASE_OSG_SERIES == '3.6' ]] && [[ $BASE_YUM_REPO != "release" ]]; then \
+       # Temporarily disable upcoming dev/testing since HTCondor 9.5.0-1
+       # removes condor-bosco
+       yum-config-manager --disable osg-upcoming-${BASE_YUM_REPO}; \
+    fi && \
+    yum install -y osg-ce-bosco \
                    # FIXME: avoid htcondor-ce-collector conflict
                    htcondor-ce \
                    htcondor-ce-view \


### PR DESCRIPTION
Does the dumb thing of just creating a new GHA since we want to keep generating the old tags until the 3.5 EOL. I'm also not adding this to https://github.com/opensciencegrid/osg-images yet since it builds a base + two child containers, which is different from our "standard" builds. Here's the diff between the two workflows for an easier review:

```
--- build-container.yml	2021-09-08 09:39:28.180142616 -0500
+++ release-series-images.yml	2022-01-19 16:04:57.151945585 -0600
@@ -1,4 +1,4 @@
-name: Build container images
+name: Build release series tagged container images
 
 on:
   push:
@@ -21,12 +21,13 @@
       run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
 
   base-image-build:
-    name: compute-entrypoint:${{ matrix.repo }} image build
+    name: compute-entrypoint:${{ matrix.osg_series }}-${{ matrix.repo }} image build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: False
       matrix:
         repo: ['development', 'testing', 'release']
+        osg_series: ['3.5', '3.6']
     steps:
 
     - uses: actions/checkout@v2
@@ -35,7 +36,7 @@
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache
-        key: base-${{ matrix.repo }}-buildx-${{ github.sha }}-${{ github.run_id }}
+        key: base-${{ matrix.osg_series }}-${{ matrix.repo }}-buildx-${{ github.sha }}-${{ github.run_id }}
         # allow cache hits from previous runs of the current branch,
         # parent branch, then upstream branches, in that order
         restore-keys: |
@@ -47,14 +48,16 @@
     - name: Build Docker image
       uses: docker/build-push-action@v2.2.2
       with:
-        build-args: BASE_YUM_REPO=${{ matrix.repo }}
+        build-args: |
+          BASE_YUM_REPO=${{ matrix.repo }}
+          BASE_OSG_SERIES=${{ matrix.osg_series }}
         context: .
         pull: True
         target: base
         cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
 
   child-image-builds:
-    name: ${{ matrix.image }}:${{ matrix.repo }} image build
+    name: ${{ matrix.image }}:${{ matrix.osg_series}}-${{ matrix.repo }} image build
     runs-on: ubuntu-latest
     needs: [make-date-tag, base-image-build]
     strategy:
@@ -62,6 +65,7 @@
       matrix:
         repo: ['development', 'testing', 'release']
         image: ['hosted-ce', 'osg-ce-condor']
+        osg_series: ['3.5', '3.6']
     steps:
 
     - uses: actions/checkout@v2
@@ -70,19 +74,20 @@
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache
-        key: base-${{ matrix.repo }}-buildx-${{ github.sha }}-${{ github.run_id }}
+        key: base-${{ matrix.osg_series }}-${{ matrix.repo }}-buildx-${{ github.sha }}-${{ github.run_id }}
 
     - name: Generate tag list
       id: generate-tag-list
       env:
         REPO: ${{ matrix.repo }}
         IMAGE: ${{ matrix.image }}
+        OSG_SERIES: ${{ matrix.osg_series }}
         TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
       run: |
         docker_repo=opensciencegrid/$IMAGE
         tag_list=()
         for registry in hub.opensciencegrid.org docker.io; do
-          for image_tag in "$REPO" "$REPO-$TIMESTAMP"; do
+          for image_tag in "$OSG_SERIES-$REPO" "$OSG_SERIES-$REPO-$TIMESTAMP"; do
             tag_list+=("$registry/$docker_repo":"$image_tag")
           done
         done
```