### PR TITLE
OSG 3.6 Hosted CE cleanup (SOFTWARE-5037)

### DIFF
--- a/base/etc/condor-ce/config.d/70-container.conf
+++ b/base/etc/condor-ce/config.d/70-container.conf
@@ -6,6 +6,7 @@
 SUPERUSERS = condor@daemon.htcondor.org, root@daemon.htcondor.org
 FRIENDLY_DAEMONS = condor@daemon.htcondor.org, condor@child
 
+# TODO: Drop this config after we EOL 3.5
 # Increase frequency so that condor_meter doesn't take too long when
 # running drain-ce.h on container teardown
 SCHEDD_CRON_GRATIA_PERIOD = 15m

--- a/base/etc/condor-ce/config.d/70-container.conf
+++ b/base/etc/condor-ce/config.d/70-container.conf
@@ -6,9 +6,6 @@
 SUPERUSERS = condor@daemon.htcondor.org, root@daemon.htcondor.org
 FRIENDLY_DAEMONS = condor@daemon.htcondor.org, condor@child
 
-# TODO: Remove this after osg-ce is released in
-# https://jira.opensciencegrid.org/browse/SOFTWARE-3973
-SCHEDD_CRON_GRATIA_ARGS = -f /etc/gratia/htcondor-ce/ProbeConfig
 # Increase frequency so that condor_meter doesn't take too long when
 # running drain-ce.h on container teardown
 SCHEDD_CRON_GRATIA_PERIOD = 15m

--- a/base/etc/osg/image-config.d/50-nonroot-gratia-setup.sh
+++ b/base/etc/osg/image-config.d/50-nonroot-gratia-setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# OSG 3.6 uses non-root SchedD cron based gratia probes
+pkg-cmp-gt osg-release 3.6 && exit 0
+
 /usr/local/bin/configure-nonroot-gratia.py /etc/gratia/htcondor-ce/ProbeConfig
 
 # fixups for OSG 3.5 gratia-probe; will not be needed in OSG 3.6


### PR DESCRIPTION
Requires https://github.com/opensciencegrid/docker-software-base/pull/53

None of this is strictly necessary but hey, it's nice to clean things up