### PR TITLE
Ensure that Gratia dirs exist

### DIFF
--- a/base/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/base/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -85,13 +85,16 @@ echo "><><><><><><><><><><><><><><><><><><><"
 
 # Ensure that PVC dirs and subdirs exist and have the proper
 # ownership (SOFTWARE-4423)
-pvc_dirs=(/var/log/condor-ce/
+pvc_dirs=(/var/log/condor-ce/gratia
           /var/lib/condor-ce/execute
+          /var/lib/condor-ce/gratia/data/
+          /var/lib/condor-ce/gratia/tmp/
           /var/lib/condor-ce/spool/ceview/metrics
           /var/lib/condor-ce/spool/ceview/vos)
 mkdir -p ${pvc_dirs[*]}
 
-pvc_dirs+=(/var/lib/condor-ce
+pvc_dirs+=(/var/log/condor-ce
+           /var/lib/condor-ce
            /var/lib/condor-ce/spool
            /var/lib/condor-ce/spool/ceview)
 chown condor:condor ${pvc_dirs[*]}


### PR DESCRIPTION
Handled in 3.5 by 50-nonroot-gratia-setup.sh and handled in packaging
in 3.6 but we need to create them in case the operator is using PVCs