### PR TITLE
Don't install osg-ce-bosco in the base image (SOFTWARE-5174)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN groupadd -g 64 -r condor && \
     useradd -r -g condor -d /var/lib/condor -s /sbin/nologin \
       -u 64 -c "Owner of HTCondor Daemons" condor
 
-RUN yum install -y osg-ce-bosco \
+RUN yum install -y osg-ce \
                    # FIXME: avoid htcondor-ce-collector conflict
                    htcondor-ce \
                    htcondor-ce-view \


### PR DESCRIPTION
We only want it in the hosted-ce image (where it's already specified).