### PR TITLE
Remove load input from docker/build-push-action

### DIFF
--- a/.github/workflows/release-series-images.yml
+++ b/.github/workflows/release-series-images.yml
@@ -87,7 +87,6 @@ jobs:
     - name: Build and push hosted-ce and osg-ce-condor images
       uses: docker/build-push-action@v2.2.2
       with:
-        load: true
         push: ${{ github.event_name != 'pull_request' && startsWith(github.repository, 'opensciencegrid/') }}
         context: ${{matrix.image}}
         build-args: |


### PR DESCRIPTION
Buildx call was failing when trying to load and push at the same time