### PR TITLE
FIXME: backversion condor to avoid SetEffectiveOwner bug

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -18,6 +18,8 @@ RUN groupadd -g 64 -r condor && \
     useradd -r -g condor -d /var/lib/condor -s /sbin/nologin \
       -u 64 -c "Owner of HTCondor Daemons" condor
 
+# FIXME: backversion to avoid SetEffectiveOwner bug
+RUN yum install -y --enablerepo=osg-upcoming condor-9.12.0
 RUN yum install -y osg-ce \
                    # FIXME: avoid htcondor-ce-collector conflict
                    htcondor-ce \


### PR DESCRIPTION
We see messages like the following in the SchedLog:

```
04/26/23 17:39:56 (cid:219136) (D_AUDIT) Command=QMGMT_WRITE_CMD, peer=<128.105.82.102:38437>
04/26/23 17:39:56 (cid:219136) (D_AUDIT) AuthMethod=FS, AuthId=condor, CondorId=condor@daemon.htcondor.org
04/26/23 17:39:56 (D_ALWAYS:2) Queue super user not allowed to set owner to osgvopilot, because this instance of the schedd has never seen that user submit any jobs.
04/26/23 17:39:56 (D_ALWAYS) SetEffectiveOwner security violation: setting owner to osgvopilot when active owner is "condor"
```

This is the result of a missing "Owner" attribute in the cluster ads of jobs submitted by the job router or Gridmanager. Dev team has a fix targeted for 10.5.0.