### PR TITLE
Prepend /usr/local/{s,}bin for WN script override access

### DIFF
--- a/hosted-ce/Dockerfile
+++ b/hosted-ce/Dockerfile
@@ -13,6 +13,10 @@ RUN yum install -y osg-ce-bosco && \
 
 COPY 30-remote-site-setup.sh /etc/osg/image-config.d/
 
+# SOFTWARE-5613: ensure that /usr/local/{s,}bin is included in all
+# user's paths
+COPY etc/* /etc
+
 # HACK: override condor_ce_jobmetrics from SOFTWARE-4183 until it is released in
 # HTCondor-CE.
 COPY overrides/condor_ce_jobmetrics /usr/share/condor-ce/condor_ce_jobmetrics

--- a/hosted-ce/etc/environment.conf
+++ b/hosted-ce/etc/environment.conf
@@ -1,0 +1,1 @@
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin


### PR DESCRIPTION
(SOFTWARE-5613)

I could do away with the override scripts but I think leaving it like this makes the transition period for the WN script ownership a little clearer