### PR TITLE
More sudo env hacks (SOFTWARE-5613)

### DIFF
--- a/hosted-ce/30-remote-site-setup.sh
+++ b/hosted-ce/30-remote-site-setup.sh
@@ -253,7 +253,8 @@ done
 
 if [[ $SKIP_WN_INSTALL == 'no' ]]; then
     echo "Installing remote WN client tarballs..."
-    sudo -u condor update-all-remote-wn-clients-override --log-dir /var/log/condor-ce/
+    sudo -u condor --preserve-env=PATH \
+         update-all-remote-wn-clients-override --log-dir /var/log/condor-ce/
 else
     echo "SKIP_WNCLIENT = True" > /etc/condor-ce/config.d/50-skip-wnclient-cron.conf
     echo "Skipping remote WN client tarball installation, using CVMFS..."

--- a/hosted-ce/Dockerfile
+++ b/hosted-ce/Dockerfile
@@ -13,10 +13,6 @@ RUN yum install -y osg-ce-bosco && \
 
 COPY 30-remote-site-setup.sh /etc/osg/image-config.d/
 
-# SOFTWARE-5613: ensure that /usr/local/{s,}bin is included in all
-# user's paths
-COPY etc/* /etc
-
 # HACK: override condor_ce_jobmetrics from SOFTWARE-4183 until it is released in
 # HTCondor-CE.
 COPY overrides/condor_ce_jobmetrics /usr/share/condor-ce/condor_ce_jobmetrics

--- a/hosted-ce/etc/environment
+++ b/hosted-ce/etc/environment
@@ -1,1 +1,0 @@
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin


### PR DESCRIPTION
I think this one actually works, though

```
[root@c6989b8dc97b /]# cat /etc/environment
[root@c6989b8dc97b /]# sudo -u condor env | grep PATH
PATH=/sbin:/bin:/usr/sbin:/usr/bin
[root@c6989b8dc97b /]# sudo -u condor --preserve-env=PATH env | grep PATH
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```