### PR TITLE
Got the boolean backwards

### DIFF
--- a/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
+++ b/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
@@ -131,7 +131,7 @@ debug_file_contents $known_hosts
 # SOFTWARE-5650: the htcondor-ce-view package drops config to
 # automatically enable it.  Disable it by default at runtime.
 # Not all of these configs are marked as such in the RPM.
-if [[ ${ENABLE_CE_VIEW:=false} == 'true' ]]; then
+if [[ ${ENABLE_CE_VIEW:=false} != 'true' ]]; then
     rpm -ql htcondor-ce-view \
         | egrep '(/etc|/usr/share)/condor-ce/config\.d/.*\.conf$' \
         | xargs rm


### PR DESCRIPTION
We want to remove the config that enables the CE View when the operator hasn't requested the htcondor-ce-view