### PR TITLE
Fix mismatched build arg

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,7 +13,7 @@ LABEL maintainer "OSG Software <help@osg-htc.org>"
 # previous args have gone out of scope
 ARG BASE_OS=el9
 ARG BASE_YUM_REPO=release
-ARG BASE_OSG_SERIES=3.6
+ARG BASE_OSG_SERIES=23
 
 # Ensure that the 'condor' UID/GID matches across containers
 RUN groupadd -g 64 -r condor && \


### PR DESCRIPTION
I don't think this actually resulted in issues since our build pipeline always specifies this build arg but still...