### PR TITLE
Don't crash if /tmp/90-local.ini is missing

### DIFF
--- a/base/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/base/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -38,21 +38,19 @@ for user in $users; do
 done
 
 #kubernetes configmaps arent writeable
-stat /tmp/90-local.ini
-if [[ $? -eq 0 ]]; then
+if stat /tmp/90-local.ini; then
   cp /tmp/90-local.ini /etc/osg/config.d/90-local.ini
+  echo "Trying to populate hostname in 90-local.ini with a better value.."
+  pushd /etc/osg/config.d
+    if [[ -z "$_CONDOR_NETWORK_HOSTNAME" ]]; then
+      echo '$_CONDOR_NETWORK_HOSTNAME is empty, just using `hostname`'
+      sed -i "s/localhost/$(hostname)/" 90-local.ini
+    else
+      echo '$_CONDOR_NETWORK_HOSTNAME is nonempty, substituting it in..'
+      sed -i "s/localhost/$_CONDOR_NETWORK_HOSTNAME/" 90-local.ini
+    fi
+  popd
 fi
-
-echo "Trying to populate hostname in 90-local.ini with a better value.."
-pushd /etc/osg/config.d
-  if [[ -z "$_CONDOR_NETWORK_HOSTNAME" ]]; then
-    echo '$_CONDOR_NETWORK_HOSTNAME is empty, just using `hostname`'
-    sed -i "s/localhost/$(hostname)/" 90-local.ini
-  else
-    echo '$_CONDOR_NETWORK_HOSTNAME is nonempty, substituting it in..'
-    sed -i "s/localhost/$_CONDOR_NETWORK_HOSTNAME/" 90-local.ini
-  fi
-popd 
 
 echo "Running OSG configure.."
 # Run the OSG Configure script to set up bosco

--- a/base/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/base/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -40,13 +40,13 @@ done
 #kubernetes configmaps arent writeable
 if stat /tmp/90-local.ini; then
   cp /tmp/90-local.ini /etc/osg/config.d/90-local.ini
-  echo "Trying to populate hostname in 90-local.ini with a better value.."
+  echo "Trying to populate hostname in 90-local.ini with a better value..."
   pushd /etc/osg/config.d
     if [[ -z "$_CONDOR_NETWORK_HOSTNAME" ]]; then
       echo '$_CONDOR_NETWORK_HOSTNAME is empty, just using `hostname`'
       sed -i "s/localhost/$(hostname)/" 90-local.ini
     else
-      echo '$_CONDOR_NETWORK_HOSTNAME is nonempty, substituting it in..'
+      echo '$_CONDOR_NETWORK_HOSTNAME is nonempty, substituting it in...'
       sed -i "s/localhost/$_CONDOR_NETWORK_HOSTNAME/" 90-local.ini
     fi
   popd
@@ -58,7 +58,7 @@ osg-configure -c --verbose VERBOSE
 
 # Cert stuff
 if [ "${DEVELOPER,,}" == 'true' ]; then
-    echo "Establishing OSG Test certificate.."
+    echo "Establishing OSG Test certificate..."
     # don't do this in the image to make it smaller for prod use
     git clone https://github.com/opensciencegrid/osg-ca-generator.git
     pushd osg-ca-generator
@@ -90,7 +90,7 @@ if [ ! -f $hostcert_path ] || [ ! -f $hostkey_path ]; then
         ln -s $orig_hostcert_path $hostcert_path
         ln -s $orig_hostkey_path $hostkey_path
     else
-        echo "Establishing Let's Encrypt certificate.."
+        echo "Establishing Let's Encrypt certificate..."
         if [ -f $hostkey_path ]; then
             openssl req -new -nodes -out $hostcsr_path -key $hostkey_path -subj "/CN=$CE_HOSTNAME"
             certbot_opts="$certbot_opts --csr $hostcsr_path --cert-path $hostcert_path"


### PR DESCRIPTION
Since we have `set -e` on, if /tmp/90-local.ini is missing, then the stat call fails and the pod crashes. Also only make sed substitutions in 90-local.ini if the file exists.