### PR TITLE
HTCONDOR-2230: fix multi sudo users file

### DIFF
--- a/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
+++ b/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
@@ -48,7 +48,7 @@ function fetch_remote_os_info {
 function setup_sudo_users {
     CONDOR_SUDO_FILE=/etc/sudoers.d/10-condor-ssh
     # Replace spaces and newlines from sort ouput with commas
-    condor_sudo_users=`tr ' \n' ',' <<< $1`
+    condor_sudo_users=`tr ' \n' ',' <<< $@`
     # Remove trailing comma from list of sudo-users
     condor_sudo_users=${condor_sudo_users:0:-1}
     echo "condor ALL = ($condor_sudo_users) NOPASSWD: /usr/bin/update-remote-wn-client-override" \

--- a/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
+++ b/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
@@ -46,12 +46,9 @@ function fetch_remote_os_info {
 
 # Allow the condor user to run the WN client updater as the local users
 function setup_sudo_users {
-    users=$(get_mapped_users)
-    [[ -n $users ]] || errexit "Did not find any HTCondor-CE SCITOKENS user mappings"
-
     CONDOR_SUDO_FILE=/etc/sudoers.d/10-condor-ssh
     # Replace spaces and newlines from sort ouput with commas
-    condor_sudo_users=`tr ' \n' ',' <<< $users`
+    condor_sudo_users=`tr ' \n' ',' <<< $1`
     # Remove trailing comma from list of sudo-users
     condor_sudo_users=${condor_sudo_users:0:-1}
     echo "condor ALL = ($condor_sudo_users) NOPASSWD: /usr/bin/update-remote-wn-client-override" \
@@ -156,8 +153,11 @@ if [[ -n $BOSCO_GIT_ENDPOINT && -n $BOSCO_DIRECTORY ]]; then
 fi
 unset GIT_SSH_COMMAND
 
+users=$(get_mapped_users)
+[[ -n $users ]] || errexit "Did not find any HTCondor-CE SCITOKENS user mappings"
+
 # Setup sudoers.d file
-setup_sudo_users
+setup_sudo_users $users
 
 grep -qs '^OSG_GRID="/cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client' \
      /var/lib/osg/osg-job-environment*.conf && SKIP_WN_INSTALL=yes

--- a/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
+++ b/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
@@ -44,6 +44,21 @@ function fetch_remote_os_info {
     ssh -q "$ruser@$rhost" "cat /etc/os-release"
 }
 
+# Allow the condor user to run the WN client updater as the local users
+function setup_sudo_users {
+    users=$(get_mapped_users)
+    [[ -n $users ]] || errexit "Did not find any HTCondor-CE SCITOKENS user mappings"
+
+    CONDOR_SUDO_FILE=/etc/sudoers.d/10-condor-ssh
+    # Replace spaces and newlines from sort ouput with commas
+    condor_sudo_users=`tr ' \n' ',' <<< $users`
+    # Remove trailing comma from list of sudo-users
+    condor_sudo_users=${condor_sudo_users:0:-1}
+    echo "condor ALL = ($condor_sudo_users) NOPASSWD: /usr/bin/update-remote-wn-client-override" \
+         > $CONDOR_SUDO_FILE
+    chmod 644 $CONDOR_SUDO_FILE
+}
+
 setup_user_ssh () {
   remote_user="$1"
   remote_fqdn="$2"
@@ -141,18 +156,8 @@ if [[ -n $BOSCO_GIT_ENDPOINT && -n $BOSCO_DIRECTORY ]]; then
 fi
 unset GIT_SSH_COMMAND
 
-users=$(get_mapped_users)
-[[ -n $users ]] || errexit "Did not find any HTCondor-CE SCITOKENS user mappings"
-
-# Allow the condor user to run the WN client updater as the local users
-CONDOR_SUDO_FILE=/etc/sudoers.d/10-condor-ssh
-# Replace spaces and newlines from sort ouput with commas
-condor_sudo_users=`tr ' \n' ',' <<< $users`
-# Remove trailing comma from list of sudo-users
-condor_sudo_users=${condor_sudo_users:0:-1}
-echo "condor ALL = ($condor_sudo_users) NOPASSWD: /usr/bin/update-remote-wn-client-override" \
-      > $CONDOR_SUDO_FILE
-chmod 644 $CONDOR_SUDO_FILE
+# Setup sudoers.d file
+setup_sudo_users
 
 grep -qs '^OSG_GRID="/cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client' \
      /var/lib/osg/osg-job-environment*.conf && SKIP_WN_INSTALL=yes

--- a/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
+++ b/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
@@ -50,7 +50,7 @@ function setup_sudo_users {
 
     CONDOR_SUDO_FILE=/etc/sudoers.d/10-condor-ssh
     # Replace spaces and newlines from sort ouput with commas
-    condor_sudo_users=`tr ' \n' ',' <<< $users`
+    condor_sudo_users=$(tr ' \n' ',' <<< "$users")
     # Remove trailing comma from list of sudo-users
     condor_sudo_users=${condor_sudo_users:0:-1}
     echo "condor ALL = ($condor_sudo_users) NOPASSWD: /usr/bin/update-remote-wn-client-override" \

--- a/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
+++ b/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
@@ -46,9 +46,11 @@ function fetch_remote_os_info {
 
 # Allow the condor user to run the WN client updater as the local users
 function setup_sudo_users {
+    users=$1
+
     CONDOR_SUDO_FILE=/etc/sudoers.d/10-condor-ssh
     # Replace spaces and newlines from sort ouput with commas
-    condor_sudo_users=`tr ' \n' ',' <<< $@`
+    condor_sudo_users=`tr ' \n' ',' <<< $users`
     # Remove trailing comma from list of sudo-users
     condor_sudo_users=${condor_sudo_users:0:-1}
     echo "condor ALL = ($condor_sudo_users) NOPASSWD: /usr/bin/update-remote-wn-client-override" \
@@ -157,7 +159,7 @@ users=$(get_mapped_users)
 [[ -n $users ]] || errexit "Did not find any HTCondor-CE SCITOKENS user mappings"
 
 # Setup sudoers.d file
-setup_sudo_users $users
+setup_sudo_users "$users"
 
 grep -qs '^OSG_GRID="/cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client' \
      /var/lib/osg/osg-job-environment*.conf && SKIP_WN_INSTALL=yes

--- a/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
+++ b/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh
@@ -146,7 +146,10 @@ users=$(get_mapped_users)
 
 # Allow the condor user to run the WN client updater as the local users
 CONDOR_SUDO_FILE=/etc/sudoers.d/10-condor-ssh
-condor_sudo_users=`tr ' ' ',' <<< $users`
+# Replace spaces and newlines from sort ouput with commas
+condor_sudo_users=`tr ' \n' ',' <<< $users`
+# Remove trailing comma from list of sudo-users
+condor_sudo_users=${condor_sudo_users:0:-1}
 echo "condor ALL = ($condor_sudo_users) NOPASSWD: /usr/bin/update-remote-wn-client-override" \
       > $CONDOR_SUDO_FILE
 chmod 644 $CONDOR_SUDO_FILE


### PR DESCRIPTION
[HTCONDOR-2230](https://opensciencegrid.atlassian.net/browse/HTCONDOR-2230):
The [30-remote-site-setup.sh](https://github.com/opensciencegrid/docker-compute-entrypoint/blame/master/hosted-ce/etc/osg/image-config.d/30-remote-site-setup.sh#L144-L149) setup script does not handle newlines in the output of the returned list of users from [get_mapped_users()](https://github.com/opensciencegrid/docker-compute-entrypoint/blame/master/base/etc/osg/image-config.d/ce-common-startup#L5-L12) resulting in invalid information in the produced `10-condor-ssh` file. This PR adds newlines to the list of characters to be replaced by `tr` and trims the trailing comma to help solve this issue.

[HTCONDOR-2230]: https://opensciencegrid.atlassian.net/browse/HTCONDOR-2230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ