### PR TITLE
Create token dir and token owned by root:root instead of condor:condor

### DIFF
--- a/osg-ce-condor/usr/local/bin/update-secrets
+++ b/osg-ce-condor/usr/local/bin/update-secrets
@@ -29,7 +29,7 @@ fi
 # A token.
 if [[ -f /root/secrets/token ]]; then
     umask 077
-    install -o condor -g condor -m 0600 -D /root/secrets/token /etc/condor/tokens.d/token ||\
+    install -o root -g root -m 0600 -D /root/secrets/token /etc/condor/tokens.d/token ||\
         fail "/root/secrets/token found but unable to copy"
     umask 022
 fi


### PR DESCRIPTION
new versions of condor require these permissions:
https://htcondor.readthedocs.io/en/latest/version-history/feature-versions-23-x.html#version-23-7-2