### PR TITLE
  SOFTWARE-5924: Remove el7 builds from Github Workflows

### DIFF
--- a/.github/workflows/release-series-images.yml
+++ b/.github/workflows/release-series-images.yml
@@ -30,7 +30,7 @@ jobs:
         image: ['hosted-ce', 'osg-ce-condor']
         osg_series:
           - name: '3.6'
-            os: 'el7'
+            os: 'el9'
           - name: '23'
             os: 'el9'
     steps:


### PR DESCRIPTION
Build 3.6 images in el9 instead of el7