### PR TITLE
Install htcondor-ce-view from osg-upcoming-testing to fulfill devops requirements

### DIFF
--- a/hosted-ce/Dockerfile
+++ b/hosted-ce/Dockerfile
@@ -8,8 +8,12 @@ LABEL name "hosted-ce"
 
 ARG BASE_YUM_REPO=release
 
-RUN yum install -y osg-ce-bosco \
-                   htcondor-ce-view && \
+RUN yum install -y osg-ce-bosco && \
+    if [[ $BASE_YUM_REPO == 'release' ]]; then \
+        yum install -y --enablerepo=osg-upcoming-testing htcondor-ce-view; \
+    else \
+        yum install -y htcondor-ce-view; \
+    fi && \
     rm -rf /var/cache/yum/
 
 COPY etc/osg/image-config.d/ /etc/osg/image-config.d/

--- a/hosted-ce/Dockerfile
+++ b/hosted-ce/Dockerfile
@@ -8,11 +8,10 @@ LABEL name "hosted-ce"
 
 ARG BASE_YUM_REPO=release
 
-RUN yum install -y osg-ce-bosco && \
-    if [[ $BASE_YUM_REPO == 'release' ]]; then \
-        yum install -y --enablerepo=osg-upcoming-testing htcondor-ce-view; \
+RUN if [[ $BASE_YUM_REPO == 'release' ]]; then \
+        yum install -y --enablerepo=osg-upcoming-testing osg-ce-bosco htcondor-ce-view; \
     else \
-        yum install -y htcondor-ce-view; \
+        yum install -y osg-ce-bosco htcondor-ce-view; \
     fi && \
     rm -rf /var/cache/yum/
 

--- a/osg-ce-condor/Dockerfile
+++ b/osg-ce-condor/Dockerfile
@@ -3,7 +3,11 @@ ARG BASE_YUM_REPO=release
 LABEL maintainer "OSG Software <help@osg-htc.org>"
 LABEL name "osg-ce-condor"
 
-RUN yum install -y osg-ce-condor && \
+RUN if [[ $BASE_YUM_REPO == 'release' ]]; then \
+        yum install -y --enablerepo=osg-upcoming-testing osg-ce-condor; \
+    else \
+        yum install -y osg-ce-condor; \
+    fi && \
     yum clean all && \
     rm -rf /var/cache/yum/
 


### PR DESCRIPTION
… and avoid downgrade of htcondor-ce from base (which is also installed from osg-upcoming-testing).

(SOFTWARE-5941)