### PR TITLE
HTCONDOR-2549 Remove daemon.htcondor.org uid domain

### DIFF
--- a/base/etc/condor-ce/config.d/70-container.conf
+++ b/base/etc/condor-ce/config.d/70-container.conf
@@ -3,8 +3,8 @@
 # Admin commands are limited to localhost-only authN methods
 # so we can ignore the IP address for authZ purposes, which
 # was an issue because of the many valid IP addresses in k8s
-SUPERUSERS = condor@daemon.htcondor.org, root@daemon.htcondor.org
-FRIENDLY_DAEMONS = condor@daemon.htcondor.org, condor@child
+SUPERUSERS = condor@$(UID_DOMAIN), root@$(UID_DOMAIN)
+FRIENDLY_DAEMONS = condor@$(UID_DOMAIN), condor@child
 
 # Keep the remote WN client up-to-date
 if ! defined SKIP_WNCLIENT


### PR DESCRIPTION
Use the local UID_DOMAIN for the identity of 'condor' clients. This matches the change made in the base CE configuration.