### PR TITLE
Install the 'perl(filetest)' dependency, needed for osg-ca-scripts

### DIFF
--- a/hosted-ce/Dockerfile
+++ b/hosted-ce/Dockerfile
@@ -9,9 +9,9 @@ LABEL name "hosted-ce"
 ARG BASE_YUM_REPO=release
 
 RUN if [[ $BASE_YUM_REPO == 'release' ]]; then \
-        yum install -y --enablerepo=osg-upcoming-testing osg-ce-bosco htcondor-ce-view; \
+        yum install -y --enablerepo=osg-upcoming-testing osg-ce-bosco htcondor-ce-view 'perl(filetest)'; \
     else \
-        yum install -y osg-ce-bosco htcondor-ce-view; \
+        yum install -y osg-ce-bosco htcondor-ce-view 'perl(filetest)'; \
     fi && \
     rm -rf /var/cache/yum/
 


### PR DESCRIPTION
(which we use to put CA certs into the WN client we ship to the head node)

This is a virtual dependency, provided by perl, perl-interpreter, or perl-filetest on EL7, EL8, or EL9, respectively.