### PR TITLE
SOFTWARE-6027: install hosted-ce from 24-testing

### DIFF
--- a/.github/workflows/release-series-images.yml
+++ b/.github/workflows/release-series-images.yml
@@ -77,6 +77,9 @@ jobs:
         docker_repo=$PROJECT/$IMAGE
         tag_list=()
         for registry in hub.opensciencegrid.org docker.io; do
+          if [[ $registry == 'docker.io' && $PROJECT == 'osg-htc' ]]; then
+            continue
+          fi
           for image_tag in "$OSG_SERIES-$REPO" "$OSG_SERIES-$REPO-$TIMESTAMP"; do
             tag_list+=("$registry/$docker_repo":"$image_tag")
           done

--- a/.github/workflows/release-series-images.yml
+++ b/.github/workflows/release-series-images.yml
@@ -31,8 +31,10 @@ jobs:
         osg_series:
           - name: '23'
             os: 'el9'
+            project: 'opensciencegrid'
           - name: '24'
             os: 'el9'
+            project: 'osg-htc'
     steps:
 
     - uses: actions/checkout@v3
@@ -69,9 +71,10 @@ jobs:
         REPO: ${{ matrix.repo }}
         IMAGE: ${{ matrix.image }}
         OSG_SERIES: ${{ matrix.osg_series.name }}
+        PROJECT: ${{ matrix.osg_series.project }}
         TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
       run: |
-        docker_repo=opensciencegrid/$IMAGE
+        docker_repo=$PROJECT/$IMAGE
         tag_list=()
         for registry in hub.opensciencegrid.org docker.io; do
           for image_tag in "$OSG_SERIES-$REPO" "$OSG_SERIES-$REPO-$TIMESTAMP"; do
@@ -96,5 +99,5 @@ jobs:
         context: ${{matrix.image}}
         build-args: |
           BASE_YUM_REPO=${{ matrix.repo }}
-          BASE_OSG_SERIES=${{ matrix.osg_series }}
+          BASE_OSG_SERIES=${{ matrix.osg_series.name }}
         tags: "${{ steps.generate-tag-list.outputs.taglist }}"

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,7 +5,7 @@
 # Specify the opensciencegrid/software-base image tag
 ARG BASE_OS=el9
 ARG BASE_YUM_REPO=release
-ARG BASE_OSG_SERIES=23
+ARG BASE_OSG_SERIES=24
 
 FROM opensciencegrid/software-base:$BASE_OSG_SERIES-$BASE_OS-$BASE_YUM_REPO
 LABEL maintainer "OSG Software <help@osg-htc.org>"

--- a/hosted-ce/Dockerfile
+++ b/hosted-ce/Dockerfile
@@ -7,9 +7,15 @@ LABEL maintainer "OSG Software <help@osg-htc.org>"
 LABEL name "hosted-ce"
 
 ARG BASE_YUM_REPO=release
+ARG BASE_OSG_SERIES=24
+
 
 RUN if [[ $BASE_YUM_REPO == 'release' ]]; then \
-        yum install -y --enablerepo=osg-upcoming-testing osg-ce-bosco htcondor-ce-view 'perl(filetest)'; \
+        if [[ $BASE_OSG_SERIES == '23' ]]; then \
+          yum install -y --enablerepo=osg-upcoming-testing osg-ce-bosco htcondor-ce-view 'perl(filetest)'; \
+        else \
+          yum install -y --enablerepo=osg-testing osg-ce-bosco htcondor-ce-view 'perl(filetest)'; \
+        fi \
     else \
         yum install -y osg-ce-bosco htcondor-ce-view 'perl(filetest)'; \
     fi && \


### PR DESCRIPTION
- osg-ce-bosco was moved from osg-upcoming-testing to osg-main-testing between osg 23 and 24, which was causing 24-release builds to fail since there's no osg-ce in release there yet
- Also, fix issue where 24 builds weren't pushing to osg-htc