### PR TITLE
SOFTWARE-6149: detect osg-configure changes for [Pilot] updates

### DIFF
--- a/base/etc/cron.d/osg-configure
+++ b/base/etc/cron.d/osg-configure
@@ -1,0 +1,1 @@
+*/15 * * * * root /usr/local/bin/osg-configure-cron.sh

--- a/base/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/base/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -38,23 +38,23 @@ for user in $users; do
     chown "$user": "$user_idtoken_dir"
 done
 
-#kubernetes configmaps arent writeable
-if stat /tmp/90-local.ini; then
-  cp /tmp/90-local.ini /etc/osg/config.d/90-local.ini
-  echo "Trying to populate hostname in 90-local.ini with a better value..."
-  pushd /etc/osg/config.d
-    if [[ -z "$_CONDOR_NETWORK_HOSTNAME" ]]; then
-      echo '$_CONDOR_NETWORK_HOSTNAME is empty, just using `hostname`'
-      sed -i "s/localhost/$(hostname)/" 90-local.ini
-    else
-      echo '$_CONDOR_NETWORK_HOSTNAME is nonempty, substituting it in...'
-      sed -i "s/localhost/$_CONDOR_NETWORK_HOSTNAME/" 90-local.ini
-    fi
-  popd
-fi
+# FIXME: this can be removed after all Hosted CEs have been updated to
+# the chart that dumps osg-configure config into /tmp/etc/osg/config.d/
+[[ -f /tmp/90-local.ini ]] && cp /tmp/90-local.ini /etc/osg/config.d/90-local.ini
+
+# Kubernetes configmaps arent writeable. Ideally we could just point osg-configure at another directory 
+[[ -d /tmp/etc/osg/config.d ]] && cp /tmp/etc/osg/config.d/*.ini /etc/osg/config.d/
+
+echo "Populating osg-configure hostname with a better value..."
+cat <<EOF >> "$(mktemp -p /etc/osg/config.d 95-hostname-override-XXX.conf)"
+[Site Information]
+host_name = ${_condor_NETWORK_HOSTNAME:-$(hostname)}
+EOF
 
 echo "Running OSG configure.."
 # Run the OSG Configure script to set up bosco
+mkdir -p /var/cache/osg/
+cat /etc/osg/config.d/* | sha256sum > /var/cache/osg/config-sha256.txt
 osg-configure -c --verbose VERBOSE
 
 # Cert stuff

--- a/base/usr/local/bin/osg-configure-cron.sh
+++ b/base/usr/local/bin/osg-configure-cron.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Run osg-configure if we detect config changes
+
+echoerr() { printf "%s\n" "$*" >&2; }
+
+if [[ $(ps -eo cmd | grep -q 'osg-configure -c') ]]; then
+    echoerr "ERROR: osg-configure already running, exiting."
+    exit 1
+fi
+
+cached_checksum_dir=/var/cache/osg/
+cached_checksum_path=$cached_checksum_dir/config-sha256.txt
+config_checksum=$(cat /etc/osg/config.d/* | sha256sum)
+cached_config_checksum=$(cat "$cached_checksum_path" 2> /dev/null)
+
+if [[ -z $cached_config_checksum ]]; then
+    echoerr "WARNING: no existing config checksum found. Writing new checksum to '/var/cache/osg/config-sha256.txt'."
+    mkdir -p $cached_checksum_dir
+    echo "$config_checksum" > "$cached_checksum_path"
+fi
+
+if [[ $config_checksum == $cached_config_checksum ]]; then
+    echoerr "No changes detected in /etc/osg/config.d, exiting."
+   exit 0
+fi
+
+osg-configure -c


### PR DESCRIPTION
I'm not entirely sure that any of this is necessary: if updating the values file to update the ConfigMap restarts everything, then this is all moot. However, I can't readily test config propagation until we remove the subPath from the corresponding volume mount and I don't want to a) volumeMount over all of `/tmp` or b) risk breaking all production CEs because the location of the source config file changed.