### PR TITLE
SOFTWARE-6149: actually propagate detected config changes

### DIFF
--- a/base/etc/osg/image-config.d/20-osg-ce-setup.sh
+++ b/base/etc/osg/image-config.d/20-osg-ce-setup.sh
@@ -54,7 +54,7 @@ EOF
 echo "Running OSG configure.."
 # Run the OSG Configure script to set up bosco
 mkdir -p /var/cache/osg/
-cat /etc/osg/config.d/* | sha256sum > /var/cache/osg/config-sha256.txt
+sha256sum /etc/osg/config.d/* > /var/cache/osg/config-sha256.txt
 osg-configure -c --verbose VERBOSE
 
 # Cert stuff

--- a/base/usr/local/bin/osg-configure-cron.sh
+++ b/base/usr/local/bin/osg-configure-cron.sh
@@ -22,7 +22,7 @@ if [[ -z $cached_config_checksum ]]; then
     echo "$config_checksum" > "$cached_checksum_path"
 fi
 
-if [[ $config_checksum == $cached_config_checksum ]]; then
+if [[ $config_checksum == "$cached_config_checksum" ]]; then
     echoerr "No changes detected in $config_dir, exiting."
    exit 0
 fi

--- a/base/usr/local/bin/osg-configure-cron.sh
+++ b/base/usr/local/bin/osg-configure-cron.sh
@@ -11,7 +11,9 @@ fi
 
 cached_checksum_dir=/var/cache/osg/
 cached_checksum_path=$cached_checksum_dir/config-sha256.txt
-config_checksum=$(cat /etc/osg/config.d/* | sha256sum)
+
+config_dir=/etc/osg/config.d/
+config_checksum=$(sha256sum "$config_dir/*")
 cached_config_checksum=$(cat "$cached_checksum_path" 2> /dev/null)
 
 if [[ -z $cached_config_checksum ]]; then
@@ -21,8 +23,9 @@ if [[ -z $cached_config_checksum ]]; then
 fi
 
 if [[ $config_checksum == $cached_config_checksum ]]; then
-    echoerr "No changes detected in /etc/osg/config.d, exiting."
+    echoerr "No changes detected in $config_dir, exiting."
    exit 0
 fi
 
+cp "/tmp/$config_dir/*.ini" /etc/osg/config.d
 osg-configure -c


### PR DESCRIPTION
I forgot to adjust this when I changed plans from volume mounting the ConfigMap over `/etc/osg/config.d`. I changed directions so that we would get the benefit of inheriting the RPM-provided default configs in that dir for free.