### PR TITLE
SOFTWARE-6149: apply config updates

### DIFF
--- a/base/usr/local/bin/osg-configure-cron.sh
+++ b/base/usr/local/bin/osg-configure-cron.sh
@@ -29,3 +29,4 @@ fi
 
 cp "/tmp/$config_dir/*.ini" /etc/osg/config.d
 osg-configure -c
+condor_ce_reconfig


### PR DESCRIPTION
Jeff reports that this is necessary for `OSG_ResourceCatalog` changes
to make their way to the schedd ad