### PR TITLE
use abs path for osg-configure

### DIFF
--- a/base/usr/local/bin/osg-configure-cron.sh
+++ b/base/usr/local/bin/osg-configure-cron.sh
@@ -31,6 +31,6 @@ fi
 
 # Perform an in-place replacement of the target dir
 rsync -a --delete "$staging_config_dir/" "$config_dir/"
-osg-configure -c
+/usr/sbin/osg-configure -c
 condor_ce_reconfig
 rm -rf "$staging_config_dir"


### PR DESCRIPTION
It seems /usr/sbin is not in the PATH for cron jobs.. updates to absolute path for osg-configure.