### PR TITLE
Stop building OSG 23 images

### DIFF
--- a/.github/workflows/release-series-images.yml
+++ b/.github/workflows/release-series-images.yml
@@ -29,22 +29,12 @@ jobs:
         repo: ['development', 'testing', 'release']
         image: ['hosted-ce', 'osg-ce-condor']
         osg_series:
-          - name: '23'
-            os: 'el9'
-            project: 'opensciencegrid'
           - name: '24'
             os: 'el9'
             project: 'osg-htc'
     steps:
 
     - uses: actions/checkout@v3
-
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v2.2.0
-      if: github.event_name != 'pull_request' && startsWith(github.repository, 'opensciencegrid/')
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Log in to OSG Harbor
       uses: docker/login-action@v2.2.0
@@ -76,13 +66,9 @@ jobs:
       run: |
         docker_repo=$PROJECT/$IMAGE
         tag_list=()
-        for registry in hub.opensciencegrid.org docker.io; do
-          if [[ $registry == 'docker.io' && $PROJECT == 'osg-htc' ]]; then
-            continue
-          fi
-          for image_tag in "$OSG_SERIES-$REPO" "$OSG_SERIES-$REPO-$TIMESTAMP"; do
-            tag_list+=("$registry/$docker_repo":"$image_tag")
-          done
+        registry=hub.opensciencegrid.org
+        for image_tag in "$OSG_SERIES-$REPO" "$OSG_SERIES-$REPO-$TIMESTAMP"; do
+          tag_list+=("$registry/$docker_repo":"$image_tag")
         done
         # This causes the tag_list array to be comma-separated below,
         # which is required for build-push-action
@@ -94,7 +80,7 @@ jobs:
       with:
         driver: docker  # If not set to docker driver, it will default to docker-container
                         # when using load for the build-push-action.
-    
+
     - name: Build and push hosted-ce and osg-ce-condor images
       uses: docker/build-push-action@v4
       with:


### PR DESCRIPTION
Since OSG 24+ images are not pushed to Docker Hub, also remove code for pushing to Docker Hub.